### PR TITLE
Fix build: Use updated google-closure-compiler

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,7 @@
 var gulp = require('gulp');
 var concat = require('gulp-concat');
 var karma = require('gulp-karma');
-var closureCompiler = require('gulp-closure-compiler');
+var closureCompiler = require('google-closure-compiler').gulp();
 var rename = require('gulp-rename');
 var replace = require('gulp-replace');
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "homepage": "https://logentries.com",
   "devDependencies": {
+    "google-closure-compiler": "^20161024.2.0",
     "gulp": "^3.6.2",
-    "gulp-closure-compiler": "^0.1.2",
     "gulp-concat": "^2.2.0",
     "gulp-karma": "^0.0.4",
     "gulp-rename": "^1.2.0",


### PR DESCRIPTION
In `master` currently, I can't run `npm run build` because the `gulp-closure-compiler` package seems to have changed significantly since this package was authored.

I replaced it with google's official package and it builds again (with some warnings)