### PR TITLE
Send column associated to an error when available

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "test": "karma start karma.conf-ci.js",
     "build": "gulp build",
+    "localchrome": "karma start --single-run --browsers Chrome",
     "localtest": "karma start; jshint src/ test/leSpec.js"
   },
   "repository": {
@@ -30,6 +31,7 @@
     "gulp-replace": "^0.2.0",
     "jshint": "^2.5.10",
     "karma": "^0.12.16",
+    "karma-chrome-launcher": "^2.0.0",
     "karma-cli": "0.0.4",
     "karma-jasmine": "^0.1.5",
     "karma-phantomjs-launcher": "^0.1.4",

--- a/src/le.js
+++ b/src/le.js
@@ -4,7 +4,7 @@
  */
 
 /*jslint browser:true*/
-/*global define, module, exports, console, global */
+/*global define, module, exports, console, global, JSON */
 
 /** @param {Object} window */
 (function (root, factory) {
@@ -101,10 +101,10 @@
 
         if (options.catchall) {
             var oldHandler = window.onerror;
-            var newHandler = function(msg, url, line) {
-                _rawLog({error: msg, line: line, location: url}).level('ERROR').send();
+            var newHandler = function(msg, url, line, column, error) {
+                _rawLog({error: msg, line: line, column: column, location: url}).level('ERROR').send();
                 if (oldHandler) {
-                    return oldHandler(msg, url, line);
+                    return oldHandler(msg, url, line, column, error);
                 } else {
                     return false;
                 }
@@ -271,7 +271,7 @@
                     request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
                     request.setRequestHeader('Content-type', 'application/json');
                 }
-                
+
                 if (request.overrideMimeType) {
                     request.overrideMimeType('text');
                 }

--- a/test/leSpec.js
+++ b/test/leSpec.js
@@ -1,5 +1,5 @@
 /*jshint loopfunc:true*/
-/*globals describe, it, expect, LE, sinon, afterEach, beforeEach, jasmine, window, console, spyOn, XDomainRequest, XMLHttpRequest*/
+/*globals describe, it, expect, LE, sinon, afterEach, beforeEach, jasmine, window, console, spyOn, XDomainRequest, XMLHttpRequest, JSON*/
 var GLOBAL = this;
 var TOKEN = 'test_token';
 


### PR DESCRIPTION
ref: https://developer.mozilla.org/en/docs/Web/API/GlobalEventHandlers/onerror#window.onerror

Additionally, call the `oldHandler` with all possible parameters implemented by browsers today.